### PR TITLE
Ajout d'identifiants générés pour les tuiles régions, départements et communes

### DIFF
--- a/generate-mbtiles.sh
+++ b/generate-mbtiles.sh
@@ -9,13 +9,13 @@ echo "Génération des tuiles vectorielles découpage administratif"
 mkdir -p dist
 
 #echo "Régions"
-tippecanoe -l regions --no-tile-stats --drop-densest-as-needed --detect-shared-borders -Z3 -z12  -f -o dist/regions.mbtiles sources/regions-5m.geojson.gz
+tippecanoe -l regions --generate-ids --no-tile-stats --drop-densest-as-needed --detect-shared-borders -Z3 -z12  -f -o dist/regions.mbtiles sources/regions-5m.geojson.gz
 
 #echo "Départements"
-tippecanoe -l departements --no-tile-stats --drop-densest-as-needed --detect-shared-borders -Z3 -z12 -f -o dist/departements.mbtiles sources/departements-5m.geojson.gz
+tippecanoe -l departements --generate-ids --no-tile-stats --drop-densest-as-needed --detect-shared-borders -Z3 -z12 -f -o dist/departements.mbtiles sources/departements-5m.geojson.gz
 
 echo "Communes"
-tippecanoe -l communes --no-tile-stats --drop-densest-as-needed --detect-shared-borders -Z8 -z12 -f -o dist/communes.mbtiles sources/communes-5m.geojson.gz
+tippecanoe -l communes --generate-ids --no-tile-stats --drop-densest-as-needed --detect-shared-borders -Z8 -z12 -f -o dist/communes.mbtiles sources/communes-5m.geojson.gz
 
 echo "Merge des tuiles vectorielles"
 tile-join --attribution=Etalab --name=decoupage-administratif --no-tile-size-limit --no-tile-stats -f --output dist/decoupage-administratif.mbtiles dist/communes.mbtiles dist/departements.mbtiles dist/regions.mbtiles


### PR DESCRIPTION
Ajout de l'option `--generate-ids` pour la génération les tuiles `regions`, `departements` et `communes`.
Ce `feature.id` permettra notamment la manipulation du style de ces `layers`.

**Notes**
Il aurait été préférable d'utiliser `-use-attribute-for-id` avec le champ `code`, cependant des codes comme `2A001` ne peuvent être converti en `number` et empêche l'utilisation de cette option.