### PR TITLE
Communes associees deleguees

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ type: String (0.0)
 
 La colonne type indique soit `mairie`, soit `memorial`, soit `centre`
 
+#### Communes associées et déléguées
+
+La couche commune contient en fait à la fois les [communes associées](https://www.insee.fr/fr/metadonnees/definition/c2297) et [les communes déléguées](https://www.insee.fr/fr/metadonnees/definition/c2298)
+
+```
+ogrinfo -so -al /vsigzip/./dist/communes-associees-deleguees-5m.geojson.gz
+```
+
+```
+code: String (0.0)
+nom: String (0.0)
+type: String (0.0)
+departement: String (0.0)
+region: String (0.0)
+epci: String (0.0)
+```
+
 #### EPCI
 
 ```

--- a/build.js
+++ b/build.js
@@ -9,7 +9,7 @@ const {truncate, feature} = require('@turf/turf')
 const extractFeaturesFromShapefiles = require('./lib/extract-features-from-shapefiles')
 const mergeFeatures = require('./lib/merge-features')
 const composeFeatures = require('./lib/compose-features')
-const {communes, epci, departements, regions, communesIndexes, epciIndexes} = require('./lib/decoupage-administratif')
+const {communes, communesAssocieesDeleguees, epci, departements, regions, communesIndexes, communesAssocieesDelegueesIndexes, epciIndexes} = require('./lib/decoupage-administratif')
 
 const SOURCES_PATH = join(__dirname, 'sources')
 const DIST_PATH = join(__dirname, 'dist')
@@ -20,7 +20,7 @@ async function getSimplifiedGeometries(featuresFiles, interval) {
   return chain(readFeatures)
     .map(({properties: p, geometry}) => {
       return [
-        p.INSEE_ARM || p.INSEE_COM || p.insee,
+        p.INSEE_ARM || p.INSEE_CAD || p.INSEE_COM || p.insee,
         geometry
       ]
     })
@@ -73,6 +73,38 @@ async function computeCommunesIndex(featuresFiles, interval) {
     .fromPairs()
     .value()
 }
+
+async function computeCommunesAssocieesDelegueesIndex(featuresFiles, interval) {
+  const geometriesIndex = await getSimplifiedGeometries(featuresFiles, interval)
+  const unmergedFeatures = []
+
+  communesAssocieesDeleguees.forEach(commune => {
+    const geometries = []
+    const codes = []
+
+    if (geometriesIndex[commune.code]) {
+      geometries.push(geometriesIndex[commune.code])
+    } else {
+      console.log(`Géométrie non trouvée pour la commune ${commune.code}`)
+    }
+
+    if (geometries.length === 0) {
+      throw new Error(`Aucune géométrie pour construire le contour de la commune ${commune.code}`)
+    }
+
+    for (const geometry of geometries) {
+      unmergedFeatures.push(feature(geometry, {code: commune.code}))
+    }
+  })
+
+  const mergedFeatures = await mergeFeatures(unmergedFeatures, 'code')
+
+  return chain(mergedFeatures)
+    .map(f => [f.properties.code, f.geometry])
+    .fromPairs()
+    .value()
+}
+
 
 async function writeLayer(features, interval, layerName) {
   const precision = getPrecision(interval)
@@ -175,6 +207,40 @@ async function buildAndWriteCommunes(communesIndex, interval) {
   await writeLayer(communesFeatures, interval, 'communes')
 }
 
+async function buildAndWriteCommunesAssocieesDeleguees(communesAssocieesDelegueesIndex, interval) {
+  const communesFeatures = communesAssocieesDeleguees.map(commune => {
+    const geometry = communesAssocieesDelegueesIndex[commune.code]
+
+    const properties = {
+      code: commune.code,
+      nom: commune.nom,
+      type: commune.type,
+      departement: commune.departement,
+      region: commune.region
+    }
+
+    if (['75056', '13055', '69123'].includes(commune.code)) {
+      properties.plm = true
+    }
+
+    if (commune.commune) {
+      properties.commune = commune.commune
+    }
+
+    if (commune.code in epciIndexes.commune) {
+      properties.epci = epciIndexes.commune[commune.code].code
+    }
+
+    if (commune.collectiviteOutremer) {
+      properties.collectiviteOutremer = commune.collectiviteOutremer.code
+    }
+
+    return feature(geometry, properties)
+  })
+
+  await writeLayer(communesFeatures, interval, 'communes-associees-deleguees')
+}
+
 function getPrecision(interval) {
   if (interval < 10) {
     return 6
@@ -200,6 +266,25 @@ async function buildContours(featuresFiles, interval) {
   await buildAndWriteDepartements(communesIndex, interval)
   await buildAndWriteRegions(communesIndex, interval)
 }
+
+async function buildContours(featuresFiles, interval) {
+  console.log(`  Extraction et simplification des communes : ${interval}m`)
+  const communesIndex = await computeCommunesIndex(featuresFiles, interval)
+
+  await buildAndWriteCommunes(communesIndex, interval)
+  await buildAndWriteEPCI(communesIndex, interval)
+  await buildAndWriteDepartements(communesIndex, interval)
+  await buildAndWriteRegions(communesIndex, interval)
+}
+
+async function buildContoursCommunesAssocieesDeleguees(featuresFiles, interval) {
+  console.log(`  Extraction et simplification des communes associées et déléguées: ${interval}m`)
+  const communesAssocieesDelegueesIndex = await computeCommunesAssocieesDelegueesIndex(featuresFiles, interval)
+
+  await buildAndWriteCommunesAssocieesDeleguees(communesAssocieesDelegueesIndex, interval)
+}
+
+
 
 async function readSourcesFiles(fileNames) {
   return bluebird.mapSeries(fileNames, async fileName => {
@@ -228,6 +313,18 @@ async function main() {
     'osm-communes-com.shx'
   ])
 
+  const featuresCommunesAssocieesDelegueesFiles = await readSourcesFiles([
+    'COMMUNE_ASSOCIEE_OU_DELEGUEE.cpg',
+    'COMMUNE_ASSOCIEE_OU_DELEGUEE.shp',
+    'COMMUNE_ASSOCIEE_OU_DELEGUEE.dbf',
+    'COMMUNE_ASSOCIEE_OU_DELEGUEE.prj',
+    'COMMUNE_ASSOCIEE_OU_DELEGUEE.shx'
+  ])
+
+  await buildContoursCommunesAssocieesDeleguees(featuresCommunesAssocieesDelegueesFiles, 1000)
+  await buildContoursCommunesAssocieesDeleguees(featuresCommunesAssocieesDelegueesFiles, 100)
+  await buildContoursCommunesAssocieesDeleguees(featuresCommunesAssocieesDelegueesFiles, 50)
+  await buildContoursCommunesAssocieesDeleguees(featuresCommunesAssocieesDelegueesFiles, 5)
   await buildContours(featuresFiles, 1000)
   await buildContours(featuresFiles, 100)
   await buildContours(featuresFiles, 50)

--- a/build.js
+++ b/build.js
@@ -217,20 +217,8 @@ async function buildAndWriteCommunesAssocieesDeleguees(communesAssocieesDeleguee
       region: commune.region
     }
 
-    if (['75056', '13055', '69123'].includes(commune.code)) {
-      properties.plm = true
-    }
-
-    if (commune.commune) {
-      properties.commune = commune.commune
-    }
-
-    if (commune.code in epciIndexes.commune) {
-      properties.epci = epciIndexes.commune[commune.code].code
-    }
-
-    if (commune.collectiviteOutremer) {
-      properties.collectiviteOutremer = commune.collectiviteOutremer.code
+    if (commune.chefLieu in epciIndexes.commune) {
+      properties.epci = epciIndexes.commune[commune.chefLieu].code
     }
 
     return feature(geometry, properties)

--- a/build.js
+++ b/build.js
@@ -9,7 +9,7 @@ const {truncate, feature} = require('@turf/turf')
 const extractFeaturesFromShapefiles = require('./lib/extract-features-from-shapefiles')
 const mergeFeatures = require('./lib/merge-features')
 const composeFeatures = require('./lib/compose-features')
-const {communes, communesAssocieesDeleguees, epci, departements, regions, communesIndexes, communesAssocieesDelegueesIndexes, epciIndexes} = require('./lib/decoupage-administratif')
+const {communes, communesAssocieesDeleguees, epci, departements, regions, communesIndexes, epciIndexes} = require('./lib/decoupage-administratif')
 
 const SOURCES_PATH = join(__dirname, 'sources')
 const DIST_PATH = join(__dirname, 'dist')
@@ -80,7 +80,6 @@ async function computeCommunesAssocieesDelegueesIndex(featuresFiles, interval) {
 
   communesAssocieesDeleguees.forEach(commune => {
     const geometries = []
-    const codes = []
 
     if (geometriesIndex[commune.code]) {
       geometries.push(geometriesIndex[commune.code])
@@ -104,7 +103,6 @@ async function computeCommunesAssocieesDelegueesIndex(featuresFiles, interval) {
     .fromPairs()
     .value()
 }
-
 
 async function writeLayer(features, interval, layerName) {
   const precision = getPrecision(interval)
@@ -267,24 +265,12 @@ async function buildContours(featuresFiles, interval) {
   await buildAndWriteRegions(communesIndex, interval)
 }
 
-async function buildContours(featuresFiles, interval) {
-  console.log(`  Extraction et simplification des communes : ${interval}m`)
-  const communesIndex = await computeCommunesIndex(featuresFiles, interval)
-
-  await buildAndWriteCommunes(communesIndex, interval)
-  await buildAndWriteEPCI(communesIndex, interval)
-  await buildAndWriteDepartements(communesIndex, interval)
-  await buildAndWriteRegions(communesIndex, interval)
-}
-
 async function buildContoursCommunesAssocieesDeleguees(featuresFiles, interval) {
   console.log(`  Extraction et simplification des communes associées et déléguées: ${interval}m`)
   const communesAssocieesDelegueesIndex = await computeCommunesAssocieesDelegueesIndex(featuresFiles, interval)
 
   await buildAndWriteCommunesAssocieesDeleguees(communesAssocieesDelegueesIndex, interval)
 }
-
-
 
 async function readSourcesFiles(fileNames) {
   return bluebird.mapSeries(fileNames, async fileName => {

--- a/lib/decoupage-administratif.js
+++ b/lib/decoupage-administratif.js
@@ -1,6 +1,9 @@
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['arrondissement-municipal', 'commune-actuelle'].includes(c.type))
 
+const communesAssocieesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => ['commune-associee', 'commune-deleguee'].includes(c.type))
+
 const departements = require('@etalab/decoupage-administratif/data/departements.json')
 const regions = require('@etalab/decoupage-administratif/data/regions.json')
 const epci = require('@etalab/decoupage-administratif/data/epci.json')
@@ -10,6 +13,12 @@ const communesIndexes = {
   code: keyBy(communes, 'code'),
   departement: groupBy(communes, 'departement'),
   region: groupBy(communes, 'region')
+}
+
+const communesAssocieesDelegueesIndexes = {
+  code: keyBy(communesAssocieesDeleguees, 'code'),
+  departement: groupBy(communesAssocieesDeleguees, 'departement'),
+  region: groupBy(communesAssocieesDeleguees, 'region')
 }
 
 const departementsIndexes = {
@@ -33,10 +42,12 @@ epci.forEach(e => {
 
 module.exports = {
   communes,
+  communesAssocieesDeleguees,
   departements,
   regions,
   epci,
   communesIndexes,
+  communesAssocieesDelegueesIndexes,
   departementsIndexes,
   regionsIndexes,
   epciIndexes

--- a/prepare-sources.js
+++ b/prepare-sources.js
@@ -9,7 +9,7 @@ const decompress = require('decompress')
 const SOURCES_PATH = path.join(__dirname, 'sources')
 
 const ADMIN_EXPRESS_BASE_URL = 'http://files.opendatarchives.fr/professionnels.ign.fr/adminexpress/'
-const ADMIN_EXPRESS_FILE = 'ADMIN-EXPRESS-COG_3-0__SHP__FRA_WM_2021-05-19.7z'
+const ADMIN_EXPRESS_FILE = 'ADMIN-EXPRESS-COG_3-1__SHP__FRA_WM_2022-04-15.7z'
 
 const OSM_COMMUNES_COM_BASE_URL = 'http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/shp/'
 const OSM_COMMUNES_COM_FILE = 'communes-com-20220101-shp.zip'
@@ -42,7 +42,7 @@ async function decompressAdminExpressFiles() {
   return new Promise((resolve, reject) => {
     const extractStream = Seven.extract(getSourceFilePath(ADMIN_EXPRESS_FILE), SOURCES_PATH, {
       recursive: true,
-      $cherryPick: ['COMMUNE.*', 'ARRONDISSEMENT_MUNICIPAL.*']
+      $cherryPick: ['COMMUNE.*', 'COMMUNE_ASSOCIEE_OU_DELEGUEE.*', 'ARRONDISSEMENT_MUNICIPAL.*']
     })
 
     extractStream.on('end', () => resolve())


### PR DESCRIPTION
Ajout de leur génération.
La généralisation des géométries est gérée à part car les communes déléguées ou associées ne forment pas après fusion de leur commune chef-lieu une commune complète.